### PR TITLE
Update comments method

### DIFF
--- a/app/ticksy-slack-notifications/libs/bridge/Bridge.php
+++ b/app/ticksy-slack-notifications/libs/bridge/Bridge.php
@@ -99,7 +99,7 @@ class Bridge
             }
 
             // Get latest comment
-            $comments = $this->get_comments($ticket['ticket_id']);
+            $comments = $ticket['ticket_comments'];
             $comments = $this->filter_comments($comments);
 
             // Don't push old comments on first run


### PR DESCRIPTION
I don't know if the API changed, but the ticksy method returned the comments anyway - I had to update it to this line in order to get it working, otherwise it showed there was no comments at all.
